### PR TITLE
[#26] Make document node first-class in Literate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 Notable changes to Onya are recorded here. Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- 
 ## [Unreleased]
- -->
+
+### Fixed
+
+- **The document node is now first-class in Onya Literate.** Its `@docheader` bullets carry the same expressiveness as any node block — `@as` interpretations, `@id`, nested/reified assertions, and edges — on both parse and serialize, and `@interpretations` defaults apply to them. Previously the docheader was parsed and written as a restricted *flat* `label: value` form, so an interpretation, an `@id`, a nested assertion, or an edge on the document node was silently dropped or misparsed (e.g. `* about -> Thing` became a string property, creating no edge or target node) and lost on `write → read`. Parse and serialize now route document-node assertions through the same machinery as body nodes (`_build_assertions` / `_write_assertions`); only the document node's identity and implicit `onya:Document` type stay directive-driven (`@document`), so it still has no `# NodeID [Type]` header and is never emitted as a separate `#` block. SPEC § Document Header documents this. (#26)
 
 ## [0.4.1] - 20260714: Wildcard selector query method. networkx projection + analytics write-back.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -379,7 +379,18 @@ The document header specifies:
 - `@language`: Default language for string values
 - `@iri`: Optional block declaring extra vocabulary namespace bases (see below)
 - `@interpretations`: Optional block declaring default interpretations per property label (see [Interpretations](#interpretations-data-contract-layers))
-- Other assertions are attached to the document node
+- Any other bullet is an ordinary assertion on the document node (see below)
+
+**The `@docheader` block is the document node's block.** Aside from the built-in directives
+above (`@document`, `@nodebase`, `@schema`, `@typebase`, `@language`, and the `@iri` /
+`@interpretations` configuration stanzas), every bullet in `@docheader` is an ordinary
+assertion on the document node, with exactly the expressiveness of a bullet in any node block:
+a property or an edge, carrying `@id`, `@as`, and nested/reified assertions to any depth, and
+subject to `@interpretations` defaults. The only thing that stays directive-driven is the
+document node's **identity and type**: its id comes from `@document` and it carries the implicit
+`onya:Document` type, so it has no `# NodeID [Type]` header of its own. On serialization these
+assertions are written back as `@docheader` bullets (the document node is never emitted as a
+separate `#` block), so a rich document node round-trips in place.
 
 **Important**: The `@nodebase` directive is used exclusively for expanding node IDs (e.g., `Chuks` → `http://example.org/people/Chuks`). The `@schema` directive is used for expanding both property labels (e.g., `name` → `https://schema.org/name`) and types (e.g., `[Person]` → `https://schema.org/Person`). It should be extremely unusual for an Onya file not to have a `@schema` directive.
 
@@ -599,7 +610,7 @@ Graphs can be written back to Onya Literate with `write()`. Supply the same base
 
 An assertion's `@id` and `@as` are emitted as nested directive lines at every depth. `@as` is currently always emitted inline on each property (no generated `@interpretations` factoring), with interpretation IRIs rendered back to reserved bare names or declared abbreviations where they apply. The writer never consults an interpretation registry: serialization is a model operation, and its output must not vary with installed plugins.
 
-Document-level properties stored on the document node are emitted as top-level docheader bullets. The document node itself is not written as a `#` block.
+Document-node assertions are emitted as top-level `@docheader` bullets through the same path as body-node assertions — `@id`, `@as`, nested assertions, and edges all round-trip — so a rich document node survives `write → read` in place. The document node itself is never written as a separate `#` block; its id and implicit `onya:Document` type remain directive-driven (`@document`).
 
 ## Optional assertion provenance (`@source`)
 

--- a/pylib/serial/_literate_parse.py
+++ b/pylib/serial/_literate_parse.py
@@ -647,29 +647,16 @@ def _create_assertion(parent, pi, assertion_label, doc, parser: LiterateParser |
     return created
 
 
-def process_nodeblock(nodeblock, graph_obj, doc, parser: LiterateParser | None = None):
-    headermarks, nid, ntype, props = nodeblock
+def _build_assertions(node, props, graph_obj, doc, parser: LiterateParser | None = None) -> bool:
+    '''
+    Build assertions (properties, edges, their `@id` / `@as` directives, arbitrary nesting, and
+    `@interpretations` desugaring) onto `node` from a flat, indent-encoded list of parsed bullets.
 
-    if nid == '@docheader':
-        process_docheader(props, graph_obj, doc, parser)
-        return
-
-    nid = _resolve_node_id(nid, doc, parser)
-
-    # Get or create the node
-    if nid not in graph_obj:
-        n = graph_obj.node(nid)
-    else:
-        n = graph_obj[nid]
-
-    # Add types if specified. A node may carry a *set* of types, written
-    # whitespace-separated inside the header brackets (e.g. `[Organization lv:Client]`).
-    if ntype:
-        type_base = parser._type_base(doc) if parser else doc.typebase
-        for type_ref in TYPE_REF_PAT.findall(ntype):
-            type_iri = expand_iri(type_ref, type_base, doc=doc)
-            n.types.add(type_iri)
-
+    Shared by ordinary node blocks and the document node (`@docheader`), so the document node is
+    a first-class node at the Literate boundary: its non-directive bullets carry the same
+    expressiveness as any other node's (see SPEC § Document Header). Returns True if any assertion
+    was created (used for the empty-block warning on ordinary nodes).
+    '''
     # Nesting is tracked with a stack of (indent, assertion) frames. Each assertion's origin is
     # the nearest enclosing frame with strictly smaller indent (the node itself when none). This
     # supports arbitrary nesting depth for properties, edges, and `@id` alike.
@@ -691,7 +678,7 @@ def process_nodeblock(nodeblock, graph_obj, doc, parser: LiterateParser | None =
         # Unwind frames at this indent or deeper: they are siblings/children, not the parent.
         while stack and stack[-1][0] >= pi.indent:
             stack.pop()
-        parent = stack[-1][1] if stack else n
+        parent = stack[-1][1] if stack else node
 
         # `@id` is a directive, not an assertion: it names its enclosing assertion (the current
         # parent) rather than creating a property on it. At the node's own level (no enclosing
@@ -757,6 +744,34 @@ def process_nodeblock(nodeblock, graph_obj, doc, parser: LiterateParser | None =
                     created.interp = default
             stack.append((pi.indent, created))
 
+    return saw_assertion
+
+
+def process_nodeblock(nodeblock, graph_obj, doc, parser: LiterateParser | None = None):
+    headermarks, nid, ntype, props = nodeblock
+
+    if nid == '@docheader':
+        process_docheader(props, graph_obj, doc, parser)
+        return
+
+    nid = _resolve_node_id(nid, doc, parser)
+
+    # Get or create the node
+    if nid not in graph_obj:
+        n = graph_obj.node(nid)
+    else:
+        n = graph_obj[nid]
+
+    # Add types if specified. A node may carry a *set* of types, written
+    # whitespace-separated inside the header brackets (e.g. `[Organization lv:Client]`).
+    if ntype:
+        type_base = parser._type_base(doc) if parser else doc.typebase
+        for type_ref in TYPE_REF_PAT.findall(ntype):
+            type_iri = expand_iri(type_ref, type_base, doc=doc)
+            n.types.add(type_iri)
+
+    saw_assertion = _build_assertions(n, props, graph_obj, doc, parser)
+
     # No assertion and no type: the block ensures the node id exists but otherwise makes no change
     # to the model — usually an authoring slip or a round-trip artifact (write() emits a bare block
     # for a target-only node).
@@ -769,86 +784,97 @@ def process_nodeblock(nodeblock, graph_obj, doc, parser: LiterateParser | None =
 
 
 def process_docheader(props, graph_obj, doc, parser: LiterateParser | None = None):
+    # The `@docheader` block IS the document node's block. Two kinds of bullet live here:
+    # built-in *directives* (`@document`, `@nodebase`, `@schema`, `@typebase`, `@language`, and
+    # the `@iri:` / `@interpretations:` config stanzas), which set document fields and create no
+    # assertion; and ordinary *assertions* on the document node, which get the same full treatment
+    # as any node block (properties, edges, `@id`/`@as`, arbitrary nesting) via _build_assertions.
+    # Only the document id/type stay directive-driven (`@document` + implicit onya:Document); see
+    # SPEC § Document Header.
     outer_indent = -1
-    current_outer_prop = None
-    pending_doc_props = []
+    directive_owner = None  # None | '@iri' | '@interpretations' | 'ASSERTION'
+    assertion_props = []    # non-directive bullets (with their nested descendants) for the doc node
     for prop in props:
-        # Skip comments
-        if isinstance(prop, str):
+        if isinstance(prop, str):  # a comment: no graph meaning
+            continue
+        if isinstance(prop, tuple) and prop[0] == 'text_ref_def':
+            assertion_props.append(prop)  # registered by the shared builder
             continue
 
-        # @iri section is where key IRI prefixes can be set
-        # First property encountered determines outer indent
+        # First bullet fixes the outer indent; bullets at it are directives/assertions, deeper
+        # ones are the nested content of the current outer bullet.
         if outer_indent == -1:
             outer_indent = prop.indent
         if prop.indent == outer_indent:
-            current_outer_prop = prop
-            #Setting an IRI for this very document being parsed
-            if prop.key == '@document':
+            key = prop.key
+            if key == '@document':
                 doc.iri = prop.value.verbatim if prop.value else None
-            elif prop.key == '@language':
+                directive_owner = None
+            elif key == '@language':
                 doc.lang = prop.value.verbatim if prop.value else None
-            elif prop.key == '@nodebase' or prop.key == '@base':
+                directive_owner = None
+            elif key == '@nodebase' or key == '@base':
                 # @base is retained as a legacy alias, but @nodebase is preferred.
                 doc.nodebase = prop.value.verbatim if prop.value else None
-            elif prop.key == '@schema':
+                directive_owner = None
+            elif key == '@schema':
                 doc.schemabase = prop.value.verbatim if prop.value else None
-            elif prop.key == '@typebase':
-                # @typebase for less common cases where types need different base than properties (@schema)
+                directive_owner = None
+            elif key == '@typebase':
+                # @typebase for less common cases where types need a different base than @schema
                 doc.typebase = prop.value.verbatim if prop.value else None
-            elif prop.key == '@iri':
-                # Prefix block only; nested lines supply mappings (not a document assertion)
-                pass
-            elif prop.key == '@interpretations':
+                directive_owner = None
+            elif key == '@iri':
+                # Prefix block only; nested lines supply mappings (not a document assertion).
+                directive_owner = '@iri'
+            elif key == '@interpretations':
                 # Interpretation defaults block; nested lines supply label -> interp mappings.
                 # Collected raw and resolved after the whole header is parsed (so @schema and
                 # @iri prefixes are known regardless of stanza order), then desugared onto each
                 # matching assertion's `interp` — the stanza itself is not part of the graph.
                 if doc.interp_defaults_raw is None:
                     doc.interp_defaults_raw = []
-            #If we have a document node to which to attach them, just attach all other properties
+                directive_owner = '@interpretations'
             else:
-                pending_doc_props.append(prop)
+                # A genuine assertion on the document node; hand it (and its descendants) to the
+                # shared builder below.
+                assertion_props.append(prop)
+                directive_owner = 'ASSERTION'
         else:
-            # Handle nested properties (attributes)
-            if current_outer_prop and current_outer_prop.key == '@iri':
+            # Nested line: belongs to the current outer bullet.
+            if directive_owner == '@iri':
                 k, uri = prop.key, prop.value.verbatim if prop.value else None
                 if k == '@nodebase' or k == '@base':
-                    # @base is retained as a legacy alias, but @nodebase is preferred.
                     doc.nodebase = uri
                 elif k == '@schema':
                     doc.schemabase = uri
                     _sync_schema_prefix(doc)
                 elif k == '@typebase':
-                    # @typebase for less common cases where types need different base than properties (@schema)
                     doc.typebase = uri
                 else:
                     _register_iri_prefix(doc, k, uri)
-            elif current_outer_prop and current_outer_prop.key == '@interpretations':
+            elif directive_owner == '@interpretations':
                 # Defer resolution: labels resolve against @schema, which may be declared
                 # after this stanza. Keep raw (label, interp-name) pairs for now.
                 if prop.value is not None:
                     if doc.interp_defaults_raw is None:
                         doc.interp_defaults_raw = []
                     doc.interp_defaults_raw.append((prop.key, prop.value.verbatim))
+            elif directive_owner == 'ASSERTION':
+                assertion_props.append(prop)  # a descendant of a document-node assertion
+            # else: nested under a scalar directive (e.g. under @document) -> ignored
 
     _sync_schema_prefix(doc)
     _check_namespace_bases(doc, strict=bool(parser and parser.strict_namespace_bases))
     _resolve_interp_defaults(doc)
 
-    # Attach all non-reserved docheader assertions to the document node (if any)
+    # Build the document node's assertions with the same machinery as any node block, so `@as`,
+    # `@id`, nested/reified assertions, and edges all round-trip.
     if doc.iri:
         if doc.iri not in graph_obj:
             doc_node = graph_obj.node(doc.iri)
         else:
             doc_node = graph_obj[doc.iri]
-        # Add onya:Document type to document nodes
-        doc_node.types.add(ONYA_DOCUMENT)
-        for prop in pending_doc_props:
-            if prop.value is None:
-                continue
-            fullprop = expand_iri(prop.key, doc.schemabase, doc=doc)
-            # Core model property values are strings; str-ify so a quoted docheader value
-            # (parsed as LITERAL) matches the plain-str form body assertions already store.
-            doc_node.add_property(fullprop, str(prop.value.verbatim))
+        doc_node.types.add(ONYA_DOCUMENT)  # implicit type for document nodes
+        _build_assertions(doc_node, assertion_props, graph_obj, doc, parser)
     return

--- a/pylib/serial/literate.py
+++ b/pylib/serial/literate.py
@@ -181,10 +181,12 @@ def write(
             for k, v in extra.items():
                 out.write(f'    * {k}: {v}\n')
         if document_s and document_s in model.nodes:
-            doc_node = model.nodes[document_s]
-            for prop in sorted(doc_node.properties, key=lambda p: str(p.label)):
-                key = _format_label(prop.label, all_prefixes, bracket_curie=bracket_curie)
-                _write_prop_line(out, '', key, prop.value, nodebase, all_prefixes, textrefs)
+            # The document node is a first-class node: emit its assertions with the same full
+            # path as body nodes (@id / @as / nesting / edges), just inside @docheader rather
+            # than a `#` block (see SPEC § Document Header). The directives above are document
+            # fields, not stored assertions, so there is no double-emission.
+            _write_assertions(model.nodes[document_s], out, '', nodebase, all_prefixes,
+                              bracket_curie, textrefs)
         out.write('\n')
 
     for nid in sorted(model.nodes.keys(), key=str):

--- a/test/test_docheader_roundtrip.py
+++ b/test/test_docheader_roundtrip.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# test_docheader_roundtrip.py
+'''
+The document node is a first-class node at the Onya Literate boundary (SPEC § Document Header,
+ticket #26). Its `@docheader` bullets carry the same expressiveness as any node block —
+`@as`, `@id`, nested/reified assertions, and edges — on both parse and serialize; only the
+document id/type stay directive-driven (`@document` + implicit `onya:Document`).
+
+    pytest -s test/test_docheader_roundtrip.py
+'''
+
+import warnings
+from io import StringIO
+
+from amara.iri import I
+
+from onya.graph import graph
+from onya.serial.literate import LiterateParser, write
+from onya.terms import ONYA_INTERP, ONYA_DOCUMENT
+
+
+DOC_IRI = I('http://e.o/doc')
+
+
+def _parse(src):
+    g = graph()
+    LiterateParser().parse(src, g)
+    return g
+
+
+def _roundtrip(g):
+    out = StringIO()
+    write(g, out=out, document='http://e.o/doc', nodebase='http://e.o/', schema='https://schema.org/')
+    text = out.getvalue()
+    with warnings.catch_warnings():  # target-only nodes warn as empty blocks; irrelevant here
+        warnings.simplefilter('ignore')
+        return _parse(text), text
+
+
+def _props(node):
+    return {str(p.label).rsplit('/', 1)[-1]: p for p in node.properties}
+
+
+def _edges(node):
+    return {str(e.label).rsplit('/', 1)[-1]: e for e in node.edges}
+
+
+HEADER = '''# @docheader
+* @document: http://e.o/doc
+* @nodebase: http://e.o/
+* @schema: https://schema.org/
+'''
+
+
+# --- interpretations on document-node properties -------------------------------------
+
+def test_inline_as_on_doc_property_round_trips():
+    g = _parse(HEADER + '* metric: 5\n  * @as: number\n')
+    p = _props(g[DOC_IRI])['metric']
+    assert p.interp == ONYA_INTERP('number')
+    g2, text = _roundtrip(g)
+    assert '@as: number' in text
+    assert _props(g2[DOC_IRI])['metric'].interp == ONYA_INTERP('number')
+
+
+def test_interpretations_default_applies_to_doc_property():
+    g = _parse(HEADER + '* @interpretations:\n    * mass: number\n* mass: 7\n')
+    assert _props(g[DOC_IRI])['mass'].interp == ONYA_INTERP('number')
+
+
+def test_inline_as_overrides_docheader_default_on_doc_property():
+    src = HEADER + '* @interpretations:\n    * mass: number\n* mass: 7\n  * @as: text\n'
+    g = _parse(src)
+    assert _props(g[DOC_IRI])['mass'].interp == ONYA_INTERP('text')  # inline wins
+
+
+# --- nesting, @id, edges on the document node ----------------------------------------
+
+def test_nested_assertion_on_doc_property_round_trips():
+    g = _parse(HEADER + '* title: Doc\n  * lang: en\n')
+    title = _props(g[DOC_IRI])['title']
+    assert _props(title)['lang'].value == 'en'
+    g2, _ = _roundtrip(g)
+    assert _props(_props(g2[DOC_IRI])['title'])['lang'].value == 'en'
+
+
+def test_doc_edge_creates_target_and_round_trips():
+    g = _parse(HEADER + '* about -> Thing\n')
+    e = _edges(g[DOC_IRI])['about']
+    assert e.target.id == I('http://e.o/Thing') and I('http://e.o/Thing') in g.nodes
+    g2, text = _roundtrip(g)
+    assert '* about -> Thing' in text
+    assert _edges(g2[DOC_IRI])['about'].target.id == I('http://e.o/Thing')
+
+
+def test_doc_assertion_id_addressable_as_edge_target():
+    '''An @id on a doc-node edge names it; another doc-node edge can target that assertion.'''
+    src = HEADER + '* rel -> Other\n  * @id: doc-rel\n* cites -> doc-rel\n'
+    g = _parse(src)
+    edges = _edges(g[DOC_IRI])
+    assert edges['rel'].id == I('http://e.o/doc-rel')
+    assert edges['cites'].target is edges['rel']  # edge targets the identified assertion
+    assert g.assertion_ids[I('http://e.o/doc-rel')] is edges['rel']
+    # survives a round trip
+    g2, text = _roundtrip(g)
+    assert '@id: doc-rel' in text
+    edges2 = _edges(g2[DOC_IRI])
+    assert edges2['cites'].target is edges2['rel']
+
+
+# --- idempotence & regressions -------------------------------------------------------
+
+def test_write_is_idempotent_over_rich_docheader():
+    src = (HEADER + '* metric: 5\n  * @as: number\n* title: Doc\n  * lang: en\n'
+           '* rel -> Other\n  * @id: doc-rel\n* cites -> doc-rel\n')
+    g = _parse(src)
+    _, text1 = _roundtrip(g)
+    g2 = _parse(text1)
+    _, text2 = _roundtrip(g2)
+    assert text1 == text2
+
+
+def test_directives_and_document_type_still_parse():
+    '''Regression: directives keep working and the document node keeps its implicit type.'''
+    src = ('# @docheader\n* @document: http://e.o/doc\n* @nodebase: http://e.o/\n'
+           '* @schema: https://schema.org/\n* @iri:\n    * acme: https://acme.example/kg\n'
+           '* title: Doc\n')
+    g = _parse(src)
+    doc = g[DOC_IRI]
+    assert ONYA_DOCUMENT in doc.types
+    assert _props(doc)['title'].value == 'Doc'
+    # @document/@nodebase/@schema did not become stored assertions on the doc node
+    assert set(_props(doc)) == {'title'}


### PR DESCRIPTION
### Fixed

- **The document node is now first-class in Onya Literate.** Its `@docheader` bullets carry the same expressiveness as any node block — `@as` interpretations, `@id`, nested/reified assertions, and edges — on both parse and serialize, and `@interpretations` defaults apply to them. Previously the docheader was parsed and written as a restricted *flat* `label: value` form, so an interpretation, an `@id`, a nested assertion, or an edge on the document node was silently dropped or misparsed (e.g. `* about -> Thing` became a string property, creating no edge or target node) and lost on `write → read`. Parse and serialize now route document-node assertions through the same machinery as body nodes (`_build_assertions` / `_write_assertions`); only the document node's identity and implicit `onya:Document` type stay directive-driven (`@document`), so it still has no `# NodeID [Type]` header and is never emitted as a separate `#` block. SPEC § Document Header documents this. (#26)